### PR TITLE
Make the IAM Principal's ARN available to the shell environment

### DIFF
--- a/src/bin/eic_parse_authorized_keys
+++ b/src/bin/eic_parse_authorized_keys
@@ -320,7 +320,7 @@ output=$(
                                     /usr/bin/logger -i -p authpriv.info "${callermessage}"
                                 fi
                                 # Return key to the ssh daemon
-                                /bin/echo "${key}"
+                                /bin/echo "environment=\"EIC_CALLER=${caller}\" ${key}"
                                 exitcode=0
                             fi
                         fi

--- a/src/deb_systemd/ssh.service.d/ec2-instance-connect.conf
+++ b/src/deb_systemd/ssh.service.d/ec2-instance-connect.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/sbin/sshd -D -o "AuthorizedKeysCommand /usr/share/ec2-instance-connect/eic_run_authorized_keys %%u %%f" -o "AuthorizedKeysCommandUser ec2-instance-connect" $SSHD_OPTS
+ExecStart=/usr/sbin/sshd -D -o "PermitUserEnvironment EIC_*" -o "AuthorizedKeysCommand /usr/share/ec2-instance-connect/eic_run_authorized_keys %%u %%f" -o "AuthorizedKeysCommandUser ec2-instance-connect" $SSHD_OPTS


### PR DESCRIPTION
Opening this PR as its easier to explain what I mean this way, interested if this is something the EIC team would like to integrate or not.

*Description of changes:*
Usings SSH's feature where authorized_keys format can contain controlling data before the key, an environment variable is set up which will make the $caller (IAM Principal's ARN) available within the login session.

One must enable this feature in the sshd config, I have used a prefixed wildcard, but it could be a single value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
