### PR TITLE
Fixed #20 AuthorizedKeysCommand error

### DIFF
--- a/src/bin/eic_curl_authorized_keys
+++ b/src/bin/eic_curl_authorized_keys
@@ -87,7 +87,7 @@ if [ "${id_exit}" -ne 0 ] ; then
 fi
 
 # Verify that we have active keys.  Fast-exit if we do not.
-keys_status="$(/usr/bin/curl -s -f -m 1 -H "${IMDS_TOKEN_HEADER}" -o /dev/null -I -w %{http_code} "${IMDS}/managed-ssh-keys/active-keys/${1}/")"
+keys_status="$(/usr/bin/curl -s -f -m 1 -H "${IMDS_TOKEN_HEADER}" -o /dev/null -I -w %{http_code} "${IMDS}/managed-ssh-keys/active-keys/${1}/")" && true
 if [ "${keys_status}" != "200" ]
 then
     # No keys for this user.   Nothing to do.


### PR DESCRIPTION
*Issue #, if available:*
#20 "error: AuthorizedKeysCommand /opt/aws/bin/eic_run_authorized_keys ...snip... failed, status 22" error

*Description of changes:*
 Because of the combination of shell option `set -e` and `curl -f`, curl
returns `22` when HTTP response is 4xx or 5xx, and `eic_curl_authorized_keys`
stops immediately because of the curl's failure.
 Added `&& true` at the end of the curl command line to turn the command into
non-`Simple Command`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
