### PR TITLE
add additional logging to eic_parse_authorized_keys 

### DIFF
--- a/src/bin/eic_parse_authorized_keys
+++ b/src/bin/eic_parse_authorized_keys
@@ -295,7 +295,17 @@ output=$(
 
             # Begin validation
             if [ -n "${instance_id}" ] && [ "${timestamp}" -ne 0 ] ; then
-                fingerprint=$(/usr/bin/ssh-keygen -lf "${pathprefix}-key" | cut -d ' ' -f 2) # Get only the actual fingerprint, ignore key size & source
+                # ssh-keygen can return error, based on that we grab the error and set rc appropriately
+                # we make sure that we capture stderr to stdout into the fingerprintval variable.
+                # then we work with fingerprintval variable and print the return code for further debugging.
+                set +e
+                fingerprintval=$(/usr/bin/ssh-keygen -vlf "${pathprefix}-key" 2>&1)
+                rc="${?}"
+                if [ $rc -ne 0 ] ; then
+                        /usr/bin/logger -i -p authpriv.info "ssh-keygen returned status ${exitcode} and fingerprintval as ${fingerprintval}"
+                fi
+                fingerprint=$(/usr/bin/echo $fingerprintval | cut -d ' ' -f 2) # Get only the actual fingerprint, ignore key size & source
+                set -e
                 # If we were told to expect a specific key and this isn't it, skip it
                 if [ -z "${expected_key}" ] || [ "$fingerprint" = "${expected_key}" ] ; then
                     # Check instance ID matches & timestamp is still valid


### PR DESCRIPTION
When SELinux is enabled on Amazon Linux 2, ssh-keygen would fail with return code 255. This would throw the error 255 in the /var/log/secure file. This does not help in further troubleshooting. 255 Can be returned because of multiple reasons
example:


```
Jan 20 14:47:36 ip-172-31-16-188 ec2-instance-connect[2591]: Querying EC2 Instance Connect keys for matching fingerprint: SHA256:SOMETHING
Jan 20 14:47:36 ip-172-31-16-188 sshd[2432]: error: AuthorizedKeysCommand /opt/aws/bin/eic_run_authorized_keys foobar SHA256:SOMETHING failed, status 255
```


However, this patch helps further debugging by printing the error messages such as follows:


```
Jan 20 15:19:44 ip-172-31-16-188 ec2-instance-connect[6309]: Querying EC2 Instance Connect keys for matching fingerprint: SHA256:SOMETHING
Jan 20 15:19:44 ip-172-31-16-188 ec2-instance-connect[6337]: ssh-keygen returned status 255 and fingerprintval as ssh-keygen: /dev/shm/eic-D8qcmDza/0-key: Permission denied
Jan 20 15:19:44 ip-172-31-16-188 sshd[6150]: error: AuthorizedKeysCommand /opt/aws/bin/eic_run_authorized_keys foobar SHA256:SOMETHING failed, status 255
```


This would help the troubleshooting in the right direction rather than thinking its a timing issue where one of the reasons could be "${timestamp}" -gt "${curtime}".

ssh-keygen is either returning -1 or -13 here, because of which we're printing Permission denied.

This patch does not change the original working of the script and only adds additional debugging. If you feel that I missed something, please let me know so that I can fix it.

-- Test suite results:
```
empty PASSED
invalid-signature PASSED
different-fingerprint PASSED
expired-timestamp PASSED
invalid-instance PASSED
missing-data PASSED
mixed PASSED
valid-key PASSED
```

*Issue #, if available:*

- Enable SELinux on AL2 and try to ssh into the system using ec2-instance-connect.

*Description of changes:*

- Added additional logging for when ssh-keygen command would fail.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
