### PR TITLE
Make EIC scripts compatible with macOS

### DIFF
--- a/src/bin/eic_curl_authorized_keys
+++ b/src/bin/eic_curl_authorized_keys
@@ -50,24 +50,7 @@ if [ -z "${instance}" ] ; then
 fi
 # Validate the instance ID is i-abcd1234 (8 or 17 char, hex)
 # We have it buffered to 32 chars to futureproof any further EC2 format changes (given some other EC2 resources are already 32 char)
-/bin/echo "${instance}" | /usr/bin/head -n 1 | /bin/grep -Eq "^i-[0-9a-f]{8,32}$" || exit 0
-# Verify we have an EC2 uuid
-if [ ! -f /sys/hypervisor/uuid ] ; then
-    # Nitro, switch to DMI check
-    if [ ! -f /sys/devices/virtual/dmi/id/board_asset_tag ] ; then
-        # We're out of options.  This is definitely not an instance.
-        /usr/bin/logger -i -p authpriv.info "EC2 Instance Connect was invoked on a non-instance and will do nothing."
-        exit 0
-    elif [ "$(/bin/cat /sys/devices/virtual/dmi/id/board_asset_tag)" != "${instance}" ] ; then
-        # The board_asset_tag does not match the instance id.  This is not a valid instance.
-        /usr/bin/logger -i -p authpriv.info "EC2 Instance Connect was invoked on a non-instance and will do nothing."
-        exit 0
-    fi
-elif [ "$(/usr/bin/cut -c1-3 < /sys/hypervisor/uuid)" != "ec2" ] ; then
-    # Leading bytes are not "ec2"
-    /usr/bin/logger -i -p authpriv.info "EC2 Instance Connect was invoked on a non-instance and will do nothing."
-    exit 0
-fi
+/bin/echo "${instance}" | /usr/bin/head -n 1 | /usr/bin/grep -Eq "^i-[0-9a-f]{8,32}$" || exit 0
 
 # At this point we're reasonably confident we're running on an EC2 instance.
 
@@ -102,9 +85,9 @@ then
     exit "${zone_exit}"
 fi
 # Validate the zone is aa-bb-#c (or aa-bb-cc-#d for special partitions like AWS GovCloud)
-/bin/echo "${zone}" | /usr/bin/head -n 1 | /bin/grep -Eq "^([a-z]+-){2,3}[0-9][a-z]$" || exit 255
+/bin/echo "${zone}" | /usr/bin/head -n 1 | /usr/bin/grep -Eq "^([a-z]+-){2,3}[0-9][a-z]$" || exit 255
 
-region=$(/bin/echo "${zone}" | /bin/sed -n 's/\(\([a-z]\+-\)\+[0-9]\+\).*/\1/p')
+region=$(/bin/echo "${zone}" | /usr/bin/sed -En 's/(([a-z]+-)+[0-9]+).*/\1/p')
 domain=$(curl_cmd "${IMDS_TOKEN_HEADER}" "${IMDS}/services/domain/")
 domain_exit="${?}"
 if [ "${domain_exit}" -ne 0 ]
@@ -125,7 +108,7 @@ fi
 
 expected_signer=$(/usr/bin/printf 'managed-ssh-signer.%s.%s' "${region}" "${domain}")
 
-userpath=$(/bin/mktemp -d /dev/shm/eic-XXXXXXXX)
+userpath=$(/usr/bin/mktemp -d /tmp/eic-XXXXXXXX)
 trap 'rm -rf "${userpath:?}"' EXIT
 
 # Read the current signer cert
@@ -146,7 +129,7 @@ then
     exit "${staple_exit}"
 fi
 
-ocsp_path=$(/bin/mktemp -d "${userpath}/eic-ocsp-XXXXXXXX")
+ocsp_path=$(/usr/bin/mktemp -d "${userpath}/eic-ocsp-XXXXXXXX")
 for word in $staple_paths
 do
     curl_cmd "${IMDS_TOKEN_HEADER}" "${IMDS}/managed-ssh-keys/signer-ocsp/${word}" | /usr/bin/base64 -d > "${ocsp_path}/${word}"
@@ -163,7 +146,13 @@ done
 keys_file="${userpath}/eic-keys"
 curl_cmd "${IMDS_TOKEN_HEADER}" "${IMDS}/managed-ssh-keys/active-keys/${1}/" > "${keys_file}"
 DIR="$( cd "$( dirname "${0}" )" && pwd )"
-ca_path=/etc/ssl/certs
+if [ "$(uname -s)" = "Darwin" ] ; then
+    ca_path="${userpath}/ca.pem"
+    security find-certificate -ap /Library/Keychains/System.keychain >> "${ca_path}"
+    security find-certificate -ap /System/Library/Keychains/SystemRootCertificates.keychain > "${ca_path}"
+else
+    ca_path=/etc/ssl/certs
+fi
 if [ -z "${2}" ] ; then
     output="$("${DIR}/eic_parse_authorized_keys" -x false -p "${keys_file}" -o "${OPENSSL}" -d "${userpath}" -s "${certificate}" -i "${instance}" -c "${expected_signer}" -a "${ca_path}" -v "${ocsp_path}")"
     exitcode=$? # not quote-escaped since this must be numeric 0-255

--- a/src/bin/eic_harvest_hostkeys
+++ b/src/bin/eic_harvest_hostkeys
@@ -31,43 +31,48 @@ if [ -z "${instance}" ] ; then
 fi
 # Validate the instance ID is i-abcd1234 (8 or 17 char, hex)
 # We have it buffered to 32 chars to futureproof any further EC2 format changes (given some other EC2 resources are already 32 char)
-/bin/echo "${instance}" | /usr/bin/head -n 1 | /bin/grep -Eq "^i-[0-9a-f]{8,32}$" || exit 255
+/bin/echo "${instance}" | /usr/bin/head -n 1 | /usr/bin/grep -Eq "^i-[0-9a-f]{8,32}$" || exit 255
 
-# Verify we have an EC2 uuid
-if [ ! -f /sys/hypervisor/uuid ] ; then
-    # Nitro, switch to DMI check
-    if [ ! -f /sys/devices/virtual/dmi/id/board_asset_tag ] ; then
-        # We're out of options.  This is definitely not an instance.
-        exit 255
-    elif [ "$(/bin/cat /sys/devices/virtual/dmi/id/board_asset_tag)" != "${instance}" ] ; then
-        # The board_asset_tag does not match the instance id.  This is not a valid instance.
-        exit 255
+# Calculate the SHA256 of standard input
+# sha256sum
+sha256sum () {
+    if [ "$(uname -s)" = "Darwin" ] ; then
+        /usr/bin/shasum -a 256 2>/dev/null
+    else
+        /usr/bin/sha256sum
     fi
-elif [ "$(/usr/bin/cut -c1-3 < /sys/hypervisor/uuid)" != "ec2" ] ; then
-    # Leading bytes are not "ec2"
-    exit 255
-fi
+}
 
 # Calculate the SHA256 of a given string
 # sha256 [string]
 sha256 () {
-    /bin/echo -n "${1}" | /usr/bin/sha256sum | /bin/sed 's/\s.*$//'
+    /bin/echo -n "${1}" | sha256sum | /usr/bin/awk '{ print $1 }'
 }
 
 # Sign a message with a given key
 # sign [key] [msg]
 sign () {
-    /usr/bin/printf "${2}" | /usr/bin/openssl dgst -binary -hex -sha256 -mac HMAC -macopt hexkey:"${1}" | /bin/sed 's/.* //'
+    /usr/bin/printf "${2}" | /usr/bin/openssl dgst -binary -hex -sha256 -mac HMAC -macopt hexkey:"${1}" | /usr/bin/sed 's/.* //'
 }
 
 # Derive a sigv4 signing key for the given secret
 # get_sigv4_key [key] [datestamp] [region name] [service name]
 getsigv4key () {
-    base="$(/bin/echo -n "AWS4${1}" | /usr/bin/od -A n -t x1 | /bin/sed ':a;N;$!ba;s/[\n ]//g')"
+    base="$(/bin/echo -n "AWS4${1}" | /usr/bin/od -A n -t x1 | /usr/bin/sed -E -e ':a' -e '$!N' -e '$!ba' -e 's/\n| //g')"
     kdate="$(sign "${base}" "${2}")"
     kregion="$(sign "${kdate}" "${3}")"
     kservice="$(sign "${kregion}" "${4}")"
     sign "${kservice}" "aws4_request"
+}
+
+# Format date with the given format string
+# fmtdate [date] [format string]
+fmtdate () {
+    if [ "$(uname -s)" = "Darwin" ] ; then
+        /bin/date -ujf "%Y-%m-%d %H:%M:%S" "${1}" "${2}"
+    else
+        /bin/date -ud "${1}" "${2}"
+    fi
 }
 
 # Verify that we have instance identity credentials.  Fast-exit if we do not.
@@ -80,13 +85,13 @@ fi
 
 #Iterates overs /etc/ssh to get the host keys
 for file in /etc/ssh/*.pub; do
-	/usr/bin/test -r "${file}" || continue
+	/bin/test -r "${file}" || continue
 	key=$(/usr/bin/awk '{$1=$1};1' < "${file}")
 	keys="${keys:+${keys},}\"${key}\""
 done
 
 #Temporary path to store request parameters
-userpath=$(/bin/mktemp -d /dev/shm/eic-hostkey-XXXXXXXX)
+userpath=$(/usr/bin/mktemp -d /tmp/eic-hostkey-XXXXXXXX)
 trap 'rm -rf "${userpath}"' EXIT
 
 #Get zone information
@@ -98,7 +103,7 @@ then
 fi
 
 # Validate the zone
-/bin/echo "${zone}" | /usr/bin/head -n 1 | /bin/grep -Eq "^([a-z]+-){2,3}[0-9][a-z]$" || exit 255
+/bin/echo "${zone}" | /usr/bin/head -n 1 | /usr/bin/grep -Eq "^([a-z]+-){2,3}[0-9][a-z]$" || exit 255
 
 # Get domain for calls
 domain=$(/usr/bin/curl -s -f -m 1 -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" "http://169.254.169.254/latest/meta-data/services/domain/")
@@ -109,12 +114,12 @@ then
 fi
 
 #Extract region from zone
-region=$(/bin/echo "${zone}" | /bin/sed -n 's/\(\([a-z]\+-\)\+[0-9]\+\).*/\1/p')
+region=$(/bin/echo "${zone}" | /usr/bin/sed -En 's/(([a-z]+-)+[0-9]+).*/\1/p')
 
 hostkeys=$(/bin/echo "${keys:?}")
 
-accountId=$(/usr/bin/curl -s -f -m 1 -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" "http://169.254.169.254/latest/dynamic/instance-identity/document" | /bin/grep -oP '(?<="accountId" : ")[^"]*(?=")')
-/bin/echo "${accountId}" | /usr/bin/head -n 1 | /bin/grep -Eq "^[0-9]{12}$" || exit 255
+accountId=$(/usr/bin/curl -s -f -m 1 -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" "http://169.254.169.254/latest/dynamic/instance-identity/document" | /usr/bin/sed -En 's/.*"accountId" : "(.*)",/\1/p')
+/bin/echo "${accountId}" | /usr/bin/head -n 1 | /usr/bin/grep -Eq "^[0-9]{12}$" || exit 255
 val='{"AccountID":"'${accountId}'","AvailabilityZone":"'${zone}'","HostKeys":['${hostkeys}'],"InstanceId":"'${instance}'"}'
 
 # Pull the creds we need for the call
@@ -124,9 +129,9 @@ if [ "${creds_exit}" -ne 0 ] ; then
     # We failed to load instance-identity credentials
     exit "${creds_exit}"
 fi
-AWS_ACCESS_KEY_ID=$(/bin/echo "${creds}" | /bin/sed -n 's/.*"AccessKeyId" : "\(.*\)",/\1/p')
-AWS_SECRET_ACCESS_KEY=$(/bin/echo "${creds}" | /bin/sed -n 's/.*"SecretAccessKey" : "\(.*\)",/\1/p')
-AWS_SESSION_TOKEN=$(/bin/echo "${creds}" | /bin/sed -n 's/.*"Token" : "\(.*\)",/\1/p')
+AWS_ACCESS_KEY_ID=$(/bin/echo "${creds}" | /usr/bin/sed -En 's/.*"AccessKeyId" : "(.*)",/\1/p')
+AWS_SECRET_ACCESS_KEY=$(/bin/echo "${creds}" | /usr/bin/sed -En 's/.*"SecretAccessKey" : "(.*)",/\1/p')
+AWS_SESSION_TOKEN=$(/bin/echo "${creds}" | /usr/bin/sed -En 's/.*"Token" : "(.*)",/\1/p')
 unset creds
 
 clearcreds () {
@@ -141,17 +146,17 @@ host="ec2-instance-connect.${region}.${domain}"
 endpoint="https://${host}"
 
 timestamp=$(/bin/date -u "+%Y-%m-%d %H:%M:%S")
-isoTimestamp=$(/bin/date -ud "${timestamp}" "+%Y%m%dT%H%M%SZ")
-isoDate=$(/bin/date -ud "${timestamp}" "+%Y%m%d")
+isoTimestamp=$(fmtdate "${timestamp}" "+%Y%m%dT%H%M%SZ")
+isoDate=$(fmtdate "${timestamp}" "+%Y%m%d")
 
 canonicalQuery="" # We are using POST data, not a querystring
 canonicalHeaders="host:${host}\nx-amz-date:${isoTimestamp}\nx-amz-security-token:${AWS_SESSION_TOKEN}\n"
 signedHeaders="host;x-amz-date;x-amz-security-token"
 
-payloadHash=$(/bin/echo -n "${val}" | /usr/bin/sha256sum | /bin/sed 's/\s.*$//')
+payloadHash=$(sha256 "${val}")
 
 canonicalRequest="$(/usr/bin/printf "POST\n/PutEC2HostKeys/\n%s\n${canonicalHeaders}\n${signedHeaders}\n%s" "${canonicalQuery}" "${payloadHash}")"
-requestHash=$(/bin/echo -n "${canonicalRequest}" | /usr/bin/sha256sum | /bin/sed 's/\s.*$//')
+requestHash=$(sha256 "${canonicalRequest}")
 
 # Derive the signature
 credentialScope="${isoDate}/${region}/ec2-instance-connect/aws4_request"

--- a/src/bin/eic_parse_authorized_keys
+++ b/src/bin/eic_parse_authorized_keys
@@ -49,8 +49,8 @@ removeprefix () {
 # Format: verifyocsp [is_debug] [openssl command] [certificate] [issuer] [ocsp directory]
 verifyocsp() {
     # First check if this cert is already trusted
-    cname=$("${2}" x509 -noout -subject -in "${3}" 2>/dev/null | /bin/sed -n -e 's/^.*CN[[:blank:]]*=[[:blank:]]*//p')
-    fingerprint=$("${2}" x509 -noout -fingerprint -sha1 -inform pem -in "${3}"  2>/dev/null | /bin/sed -n 's/SHA1 Fingerprint[[:space:]]*=[[:space:]]*\(.*\)/\1/p' | tr -d ':')
+    cname=$("${2}" x509 -noout -subject -in "${3}" 2>/dev/null | /usr/bin/sed -n -e 's/^.*CN[[:blank:]]*=[[:blank:]]*//p')
+    fingerprint=$("${2}" x509 -noout -fingerprint -sha1 -inform pem -in "${3}"  2>/dev/null | /usr/bin/sed -En 's/SHA1 Fingerprint[[:space:]]*=[[:space:]]*(.*)/\1/p' | tr -d ':')
     ocsp_out=$("${2}" ocsp -no_nonce -issuer "${4}" -cert "${3}" -VAfile "${4}" -respin "${5}/${fingerprint}" 2>/dev/null)
     ocsp_exit="${?}"
     if [ "${ocsp_exit}" -ne 0 ] || ! startswith "${ocsp_out}" "${3}: good" ; then
@@ -110,7 +110,7 @@ fi
 # Verify the signer certificate we have been provided - CN, trust chain, and revocation status
 
 # Split the chain into pieces
-/bin/echo "${signer}" | /usr/bin/awk -v dir="${tmpdir}" 'split_after==1{n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1} {print > dir "/cert" n ".pem"}'
+/bin/echo "${signer}" | /usr/bin/awk -v dir="${tmpdir}" 'split_after==1{n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1} {print > (dir "/cert" n ".pem")}'
 
 # We want visibility into the CA bundle so we can skip verifying entries in the chain that are already trusted
 if [ -d "${ca_path}" ] ; then
@@ -118,12 +118,12 @@ if [ -d "${ca_path}" ] ; then
 else
     ca_path_dir=$(dirname "${ca_path}")
 fi
-ca_bundles_dir=$(/bin/mktemp -d "${tmpdir}/eic-cert-XXXXXXXX")
-end=$(/usr/bin/find "${tmpdir}" -maxdepth 1 -type f -name "cert*.pem" -regextype sed -regex ".*/cert[0-9]\+\.pem" | wc -l)
+ca_bundles_dir=$(/usr/bin/mktemp -d "${tmpdir}/eic-cert-XXXXXXXX")
+end=$(/usr/bin/find "${tmpdir}" -maxdepth 1 -type f -name "cert*.pem" -regex '.*/cert[0-9][0-9]*\.pem' | wc -l | sed -e 's/^[[:space:]]*//g')
 if [ "${end}" -gt 0 ] ; then
     # First see if we already have them
     for i in $(/usr/bin/seq 1 "${end}") ; do
-        subject=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert${i}.pem" | /bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
+        subject=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert${i}.pem" | /usr/bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
         underscored=$(/bin/echo "${subject}" | /usr/bin/tr -s ' ' '_') 2>/dev/null
         if [ -f "${ca_path_dir}/${underscored}.pem" ] ; then
             # We already have it
@@ -131,7 +131,7 @@ if [ "${end}" -gt 0 ] ; then
         else
             if [ ! -d "${ca_path}" ] ; then
                 # Try to pull this CN from the CA bundle
-                /bin/sed -n -e '/#[[:space:]]'"$subject"'$/,$p' "${ca_path}" 2>/dev/null | /bin/sed '/-----END[[:space:]]CERTIFICATE-----.*/,$d' | /bin/sed -n '1!p' > "${ca_bundles_dir}/${subject}"
+                /usr/bin/sed -n -e '/#[[:space:]]'"$subject"'$/,$p' "${ca_path}" 2>/dev/null | /usr/bin/sed '/-----END[[:space:]]CERTIFICATE-----.*/,$d' | /usr/bin/sed -n '1!p' > "${ca_bundles_dir}/${subject}"
                 if [ -s "${ca_bundles_dir}/${subject}" ] ; then
                     /bin/echo "-----END CERTIFICATE-----" >> "${ca_bundles_dir}/${subject}"
                 else
@@ -143,12 +143,12 @@ if [ "${end}" -gt 0 ] ; then
 fi
 
 # Build the intermediate trust chain
-/bin/touch "${tmpdir}/ca-trust.pem"
+/usr/bin/touch "${tmpdir}/ca-trust.pem"
 for i in $(/usr/bin/seq 1 "${end}") ; do
   /bin/cat "${tmpdir}/cert${i}.pem" >> "${tmpdir}/ca-trust.pem"
 done
 if [ -d "${ca_path}" ] ; then
-    subject=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert${end}.pem" | /bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
+    subject=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert${end}.pem" | /usr/bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
     underscored=$(/bin/echo "${subject}" | /usr/bin/tr -s ' ' '_') 2>/dev/null
     /bin/cat "${ca_bundles_dir}/${underscored}" >> "${tmpdir}/ca-trust.pem" 2>/dev/null
 else
@@ -158,7 +158,7 @@ fi
 /bin/chmod 400 "${tmpdir}/ca-trust.pem"
 
 # Verify the CN
-signer_cn=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert.pem" | /bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
+signer_cn=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert.pem" | /usr/bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
 if [ "${signer_cn}" != "${expected_cn}" ] ; then
     fail "${is_debug}" "EC2 Instance Connect encountered an unrecognized signer certificate. No keys have been trusted."
 fi
@@ -180,13 +180,13 @@ fi
 # Iterate from first to second-to-last cert & validate OCSP staples
 /bin/mv "${tmpdir}/cert.pem" "${tmpdir}/cert0.pem" # Better naming consistency for loop
 for i in $(/usr/bin/seq 0 $((end - 1))) ; do
-    subject=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert${i}.pem" | /bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
+    subject=$("${OPENSSL}" x509 -noout -subject -in "${tmpdir}/cert${i}.pem" | /usr/bin/sed -n -e 's/^.*CN[[:space:]]*=[[:space:]]*//p')
     if [ -f "${ca_bundles_dir}/${subject}" ] ; then
         # If we encounter a certificate that's in the CA bundle we can skip the rest as implicitly trusted
         hash=$("${OPENSSL}" x509 -hash -noout -in "${tmpdir}/cert${i}.pem" 2>/dev/null)
         trusted_hash=$("${OPENSSL}" x509 -hash -noout -in "${ca_bundles_dir}/${subject}" 2>/dev/null)
-        fingerprint=$("${OPENSSL}" x509 -noout -fingerprint -sha1 -in "${tmpdir}/cert${i}.pem" 2>/dev/null | /bin/sed -n 's/SHA1 Fingerprint[[:space:]]*=[[:space:]]*\(.*\)/\1/p' | tr -d ':')
-        trusted_fingerprint=$("${OPENSSL}" x509 -noout -fingerprint -sha1 -in "${ca_bundles_dir}/${subject}" 2>/dev/null | /bin/sed -n 's/SHA1 Fingerprint[[:space:]]*=[[:space:]]*\(.*\)/\1/p' | tr -d ':')
+        fingerprint=$("${OPENSSL}" x509 -noout -fingerprint -sha1 -in "${tmpdir}/cert${i}.pem" 2>/dev/null | /usr/bin/sed -En 's/SHA1 Fingerprint[[:space:]]*=[[:space:]]*(.*)/\1/p' | tr -d ':')
+        trusted_fingerprint=$("${OPENSSL}" x509 -noout -fingerprint -sha1 -in "${ca_bundles_dir}/${subject}" 2>/dev/null | /usr/bin/sed -En 's/SHA1 Fingerprint[[:space:]]*=[[:space:]]*(.*)/\1/p' | tr -d ':')
         pkey=$("${OPENSSL}" x509 -pubkey -noout -in "${tmpdir}/cert${i}.pem")
         trusted_pkey=$("${OPENSSL}" x509 -pubkey -noout -in "${ca_bundles_dir}/${subject}" )
         if [ "${hash}" = "${trusted_hash}" ] && [ "${fingerprint}" = "${trusted_fingerprint}" ] && [ "${pkey}" = "${trusted_pkey}" ] ; then
@@ -244,7 +244,7 @@ output=$(
         caller=""
         request=""
         # We do not pre-initialize the actual key or signature fields
-        /bin/touch "${pathprefix}-signedData"
+        /usr/bin/touch "${pathprefix}-signedData"
 
         # Loop to read keys & parse out values
         # This is not sub-shelled as we want to maintain variable scope with the outer loop
@@ -282,7 +282,7 @@ output=$(
 
             # Read key signature - may be multi-line
             encodedsigfile="${pathprefix}-sig"
-            /bin/touch "${encodedsigfile}"
+            /usr/bin/touch "${encodedsigfile}"
             read -r sigline || sigline=""
             while [ "${sigline}" != "" ]
             do

--- a/src/bin/eic_run_authorized_keys
+++ b/src/bin/eic_run_authorized_keys
@@ -17,4 +17,4 @@
 # Necessary for older versions of openssh where AuthorizedKeysCommand must be a filepath
 set -e
 DIR="$( cd "$( dirname "${0}" )" && pwd )"
-/usr/bin/timeout 5s "${DIR}/eic_curl_authorized_keys" "$@"
+"${DIR}/eic_curl_authorized_keys" "${@}" & /bin/sleep 5; /bin/kill -KILL "${!}" 2>/dev/null || :


### PR DESCRIPTION
*Issue #, if available:*

#33


*Description of changes:*

- Remove system UUID check as it is specific for Linux and Windows instances. Mac instances don't have the EC2 prefix on their UUID. A platform independent way of checking if the machine is indeed is an EC2 Instance is by Inspecting the instance identity document (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html#inspect-document), already used by the script on a latter step. It's important to notice I did not implement the signature verification of the document as I considered it would be overkill.

- Change canonical paths of `grep`, `mktemp`, `sed`, and `touch` from `/bin` to `/usr/bin`. This change is also compatible with Linux.

- Change canonical paths of `test `/usr/bin` to `/bin`. This change is also compatible with Linux.

- Use `/tmp` instead of `/dev/shm`, available on both Linux and macOS.

- Change regular expressions to make them compatible with macOS versions of `find` and `sed`. New expressions are still compatible with Linux.

- When running on macOS, generate a CA bundle with `security find-certificate` and set is as `ca_path` instead of using `/etc/ssl/certs`.

- Extract `sha256sum` and `date -ud` to functions that handle each operation in specific ways for Linux and macOS.

- Use existing `sha256` function when calculating hashes. 

- Rewrite sed expressions to be compatible with BSD and GNU versions of sed.

- Replace `timeout 5` with `& /bin/sleep 5; /bin/kill -KILL $! 2> /dev/null || :` (http://blog.mediatribe.net/en/node/72/index.html) as macOS doesn't have it available. This can also be used on Linux.

- Replace `grep -oP` with `sed -En` to get `accountId` from JSON, using the same expression used to get `AccessKeyId`, `SecretAccessKey`, and `Token` from JSON.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
