### PR TITLE
Set the authlogin_yubikey selinux variable

### DIFF
--- a/rpmsrc/SPECS/generic.spec
+++ b/rpmsrc/SPECS/generic.spec
@@ -75,6 +75,10 @@ Requires(postun): /usr/sbin/userdel, systemd, systemd-units
 # Create/configure system user
 /usr/bin/getent passwd ec2-instance-connect || /usr/sbin/useradd -r -M -s /sbin/nologin ec2-instance-connect
 /usr/sbin/usermod -L ec2-instance-connect
+# Setup selinux policy to allow eic_curl_authorized_keys perform http connection
+if [ -x /usr/sbin/selinuxenabled -a -x /usr/sbin/setsebool ] ; then
+    /usr/sbin/selinuxenabled && /usr/sbin/setsebool -P authlogin_yubikey on
+fi
 
 %post
 %systemd_post ec2-instance-connect.service
@@ -151,6 +155,10 @@ fi
 if [ $1 -eq 0 ] ; then
     # Delete system user
     /usr/sbin/userdel ec2-instance-connect
+    # Restore the default selinux settings
+    if [ -x /usr/sbin/selinuxenabled -a -x /usr/sbin/setsebool ] ; then
+        /usr/sbin/selinuxenabled && /usr/sbin/setsebool -P authlogin_yubikey off
+    fi
 fi
 
 

--- a/src/bin/eic_run_authorized_keys
+++ b/src/bin/eic_run_authorized_keys
@@ -18,3 +18,6 @@
 set -e
 DIR="$( cd "$( dirname "${0}" )" && pwd )"
 /usr/bin/timeout 5s "${DIR}/eic_curl_authorized_keys" "$@"
+
+# Allow SSSD coexist with eic_curl_authorized_keys
+[ -x /usr/bin/sss_ssh_authorizedkeys ] && /usr/bin/sss_ssh_authorizedkeys "$@"


### PR DESCRIPTION
This settings is needed on RHEL/CentOS systems to let
eic_run_authorized_keys connect. When this package is uninstalled
the default settings (authlogin_yubikey off) is restored.

Second commit allows using SSSD ssh authorized key mechanism at the same time as the eic_run_authorized_keys.
